### PR TITLE
Set output field in aws config profile

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,6 +1,8 @@
 ---
 default: true
-line_length: true
+line_length:
+  line_length: true
+  code_blocks: false
 no-duplicate-header:
   siblings_only: true
 commands-show-output: false

--- a/README.md
+++ b/README.md
@@ -8,14 +8,24 @@ Installation instructions will go here.
 
 ## Usage
 
-The script requires the following environment variables to be set:
+The script accepts a number of arguments, either as environment variables or
+command-line flags:
 
-|Name|Description|Example
-|----|-----------|---------|
-|AWS_ACCOUNT_ID|AWS account number corresponding to the AWS_PROFILE account|`123456789012`
-|AWS_PROFILE|Alias for the account where this script is being run|`trussworks-id`
+    Usage:
+      main [OPTIONS]
+    Application Options:
+          --region=     The AWS region (default: us-west-2) [$AWS_REGION]
+          --account-id= The AWS account number [$AWS_ACCOUNT_ID]
+          --profile=    The AWS profile name [$AWS_PROFILE]
+          --iam-user=   The IAM user name
+          --role=       The user role type
+          --output=     The AWS CLI output format (default: json)
+    Help Options:
+      -h, --help        Show this help message
 
-For testing purposes, set the above variables in a .envrc.local file.
+For the arguments that accept either an environment variable or command-line
+flag, the environment variable takes precedence if both are provided due to the
+way go-flags works.
 
 ### Setup new IAM user
 
@@ -50,3 +60,25 @@ more than once**, as this will cause the process to fail.
    - `pre-commit install --install-hooks`
    - `direnv allow`
 1. The `.envrc` will be loaded if `direnv` is installed.
+
+### Testing
+
+For testing, create a test IAM user so as not to interfere with your primary
+user credentials and AWS config settings. The test user will need the
+`enforce-mfa` policy and permission to assume whichever role being assigned.
+Generate an access key for the user, and use those when running the script. For
+the AWS profile, do not use an existing profile name. You can use a dummy name
+for the profile; it doesn't need to match the account alias. However, you must
+use the real AWS account ID.
+
+Example:
+
+    go run cmd/main.go --role engineer --iam-user testuser --account-id 123456789012  --profile test-profile-name
+
+After running the script, try a command to ensure the new profile works as
+expected:
+
+Example (include AWS_VAULT_KEYCHAIN_NAME if the environment variable is not
+set):
+
+    AWS_VAULT_KEYCHAIN_NAME=login aws-vault exec test-profile-name -- aws sts get-caller-identity

--- a/go.mod
+++ b/go.mod
@@ -16,5 +16,5 @@ require (
 	golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.30.2
-	gopkg.in/ini.v1 v1.51.0 // indirect
+	gopkg.in/ini.v1 v1.51.0
 )


### PR DESCRIPTION
Prior to this change, the script ignored the output argument and did not
include an output field in the aws config profile due to the fact that the
vault.Profile struct does not include the output. As a workaround, this PR
adds an additional Output field to the User struct and falls back to using
the ini package directly to add the additional key.

Note: aws-vault currently ignores a custom profile's output setting. Users
can change the output in the default profile, but output settings in custom
profiles do not have an effect.

https://www.pivotaltracker.com/story/show/170386708