### PR TITLE
Remove unused tempFile definition

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -435,9 +435,6 @@ func printQRCode(payload string, tempfile *os.File) error {
 		return fmt.Errorf("unable to generate PNG: %w", err)
 	}
 
-	// Shot of Elmer's
-	tempFile := tempfile.Name()
-
 	// Write the QR PNG to the Temp File
 	if _, err := tempfile.Write(qr); err != nil {
 		tempfile.Close()


### PR DESCRIPTION
I went through this with @eeeady yesterday and the tool wasn't working due to tempFile not being defined. 

**Testing**
Manually ran through setting up Eady's IAM user 