### PR TITLE
add goreleaser to circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             - ~/.cache/pre-commit
   release:
     docker:
-      - image: *circleci_docker_primary 
+      - image: *circleci_docker_primary
     steps:
       - checkout
       - run: curl -sL https://git.io/goreleaser | bash
@@ -32,7 +32,7 @@ workflows:
     jobs:
       - validate
       - release:
-          requires: 
+          requires:
             - validate
           filters:
             branches:


### PR DESCRIPTION
Updates the circleci configuration to have a main workflow that runs both validate and release jobs but will only release on a tag using semver (what goreleaser wants anyways)