### PR TITLE
adds basic homebrew config for our tap

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,9 @@ brews:
       owner: trussworks
       name: homebrew-tap
     homepage: "https://github.com/trussworks/setup-new-aws-user"
+    commit_author:
+      name: trussworks-infra
+      email: infra+github@truss.works
 archives:
 - replacements:
     darwin: Darwin


### PR DESCRIPTION
Adds homebrew configuration to goreleaser.

Note: tested this locally... it just does it! if you check out https://github.com/trussworks/homebrew-tap/blob/master/setup-new-aws-user.rb it just does the thing.