### PR TITLE
Fix IAM Role ARN if trying to run against GovCloud

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 references:
-  circleci-docker-primary: &circleci-docker-primary trussworks/circleci-docker-primary:d7f27acdab24f86297220a43f704f23f2bab667d
+  circleci-docker-primary: &circleci-docker-primary trussworks/circleci-docker-primary:c542b22c7fb95db0a1bbe043928a457ae6fbeaca
 
 jobs:
   test:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.24.0
+    rev: v1.26.0
     hooks:
       - id: golangci-lint
 
@@ -17,6 +17,6 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.22.0
+    rev: v0.23.0
     hooks:
       - id: markdownlint

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
-
 	"log"
 	"os"
 
@@ -12,6 +11,7 @@ import (
 	"github.com/99designs/keyring"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/sts"
@@ -453,6 +453,13 @@ func checkExistingAWSProfile(profileName string, config *vault.Config) error {
 	return nil
 }
 
+func getPartition(region string) string {
+	if partition, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), region); ok {
+		return partition.ID()
+	}
+	return "aws"
+}
+
 func main() {
 	// parse command line flags
 	var options cliOptions
@@ -468,8 +475,10 @@ func main() {
 	// initialize things
 	profile := vault.Profile{
 		Name: options.AwsProfile,
-		RoleARN: fmt.Sprintf("arn:aws:iam::%v:role/%v",
-			options.AwsAccountID, options.Role),
+		RoleARN: fmt.Sprintf("arn:%s:iam::%d:role/%s",
+			getPartition(options.AwsRegion),
+			options.AwsAccountID,
+			options.Role),
 		Region: options.AwsRegion,
 	}
 

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -61,3 +61,12 @@ func TestGenerateQrCode(t *testing.T) {
 	err = generateQrCode("otpauth://totp/super@top?secret=secret", tempFile)
 	assert.NoError(t, err)
 }
+
+func TestGetPartition(t *testing.T) {
+	commPartition := getPartition("us-west-2")
+	assert.Equal(t, commPartition, "aws")
+	govPartition := getPartition("us-gov-west-1")
+	assert.Equal(t, govPartition, "aws-us-gov")
+	unknownPartition := getPartition("aws-under-the-sea")
+	assert.Equal(t, unknownPartition, "aws")
+}

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -63,10 +63,14 @@ func TestGenerateQrCode(t *testing.T) {
 }
 
 func TestGetPartition(t *testing.T) {
-	commPartition := getPartition("us-west-2")
+	commPartition, err := getPartition("us-west-2")
 	assert.Equal(t, commPartition, "aws")
-	govPartition := getPartition("us-gov-west-1")
+	assert.NoError(t, err)
+
+	govPartition, err := getPartition("us-gov-west-1")
 	assert.Equal(t, govPartition, "aws-us-gov")
-	unknownPartition := getPartition("aws-under-the-sea")
-	assert.Equal(t, unknownPartition, "aws")
+	assert.NoError(t, err)
+
+	_, err = getPartition("aws-under-the-sea")
+	assert.Error(t, err)
 }

--- a/go.sum
+++ b/go.sum
@@ -9,12 +9,6 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/aws/aws-sdk-go v1.25.17/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
-github.com/aws/aws-sdk-go v1.29.19 h1:+jifYixffn6kzWygtGWFWQMv0tDGyISZHNwugF9V2sE=
-github.com/aws/aws-sdk-go v1.29.19/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTgahTma5Xg=
-github.com/aws/aws-sdk-go v1.29.26 h1:T8LJNOVt0HZgJQySeE+1Pr3ClcX+rb7ddq/ZAjnHzDc=
-github.com/aws/aws-sdk-go v1.29.26/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTgahTma5Xg=
-github.com/aws/aws-sdk-go v1.29.29 h1:4TdSYzXL8bHKu80tzPjO4c0ALw4Fd8qZGqf1aozUcBU=
-github.com/aws/aws-sdk-go v1.29.29/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTgahTma5Xg=
 github.com/aws/aws-sdk-go v1.29.34 h1:yrzwfDaZFe9oT4AmQeNNunSQA7c0m2chz0B43+bJ1ok=
 github.com/aws/aws-sdk-go v1.29.34/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTgahTma5Xg=
 github.com/danieljoos/wincred v1.0.2 h1:zf4bhty2iLuwgjgpraD2E9UbvO+fe54XXGJbOwe23fU=
@@ -120,8 +114,6 @@ gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8
 gopkg.in/go-playground/validator.v9 v9.31.0 h1:bmXmP2RSNtFES+bn4uYuHT7iJFJv7Vj+an+ZQdDaD1M=
 gopkg.in/go-playground/validator.v9 v9.31.0/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=
 gopkg.in/ini.v1 v1.49.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
-gopkg.in/ini.v1 v1.54.0 h1:oM5ElzbIi7gwLnNbPX2M25ED1vSAK3B6dex50eS/6Fs=
-gopkg.in/ini.v1 v1.54.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/ini.v1 v1.55.0 h1:E8yzL5unfpW3M6fz/eB7Cb5MQAYSZ7GKo4Qth+N2sgQ=
 gopkg.in/ini.v1 v1.55.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=


### PR DESCRIPTION
Up til now we've been hardcoding the AWS partition, which breaks when trying to run against GovCloud. This PR looks up the AWS partition based on the region you're passing in.

Tested by running 
```
go run cmd/main.go --role admin --iam-user dynatest --profile=dynatest --account-id=<gov-account-id> --region=us-gov-west-1
go run cmd/main.go --role admin --iam-user dynatest --profile=dynatest --account-id=<commercial-account-id>
```