### PR TITLE
Generate separate base profile and role profiles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 references:
-  circleci-docker-primary: &circleci-docker-primary trussworks/circleci-docker-primary:c542b22c7fb95db0a1bbe043928a457ae6fbeaca
+  circleci-docker-primary: &circleci-docker-primary trussworks/circleci-docker-primary:a232f2f06cd9c7220ffb3897f1bb050b55751b6f
 
 jobs:
   test:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: git://github.com/golangci/golangci-lint
-    rev: v1.26.0
+    rev: v1.27.0
     hooks:
       - id: golangci-lint
 
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v3.1.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -17,6 +17,6 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.23.0
+    rev: v0.23.1
     hooks:
       - id: markdownlint

--- a/README.md
+++ b/README.md
@@ -53,6 +53,25 @@ Before running this tool, you will need to following pieces of information
 aws-vault exec AWS_PROFILE -- aws sts get-session
 ```
 
+## How this tool modifies your ~/.aws/config
+
+While your AWS access keys are stored in a password protected keychain managed by `aws-vault`, the configuration for how you should access AWS accounts lives in ~/.aws/config. The setup-new-aws-user tool creates two profiles your `~/.aws/config`. The first is the base profile containing your long lived AWS Access Keys and is tied to your IAM user and MFA device. Since these keys are long lived, you should be rotating them regularly with `aws-vault rotate`. The second profile is the IAM role granting you elevated access to the AWS account. Typically these IAM roles are named `admin` or `engineer` and only uses temporary credentials leveraging AWS's Security Token Service (STS). Below is an example config generated from this tool.
+
+
+```ini
+[profile corp-id-base]
+mfa_serial=arn:aws:iam::123456789012:mfa/alice
+region=us-west-2
+output=json
+
+[profile corp-id]
+source_profile=corp-id-base
+mfa_serial=arn:aws:iam::123456789012:mfa/alice
+role_arn=arn:aws:iam::123456789012:role/admin
+region=us-west-2
+output=json
+```
+
 ## Development setup
 
 1. First, install these packages: `brew install pre-commit direnv go`

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -46,7 +46,8 @@ type cliOptions struct {
 // User holds information for the AWS user being configured by this script
 type User struct {
 	Name            string
-	Profile         *vault.Profile
+	BaseProfile     *vault.Profile
+	RoleProfile     *vault.Profile
 	Output          string
 	Config          *vault.Config
 	AccessKeyID     string
@@ -121,7 +122,7 @@ func (u *User) newSession() (*session.Session, error) {
 				AccessKeyID:     u.AccessKeyID,
 				SecretAccessKey: u.SecretAccessKey,
 			}),
-			Region: aws.String(u.Profile.Region),
+			Region: aws.String(u.BaseProfile.Region),
 		},
 	})
 	if err != nil {
@@ -138,7 +139,7 @@ func (u *User) newMFASession() (*session.Session, error) {
 	}
 	stsClient := sts.New(basicSession)
 	getSessionTokenOutput, err := stsClient.GetSessionToken(&sts.GetSessionTokenInput{
-		SerialNumber: aws.String(u.Profile.MFASerial),
+		SerialNumber: aws.String(u.BaseProfile.MFASerial),
 		TokenCode:    aws.String(mfaToken),
 	})
 	if err != nil {
@@ -151,7 +152,7 @@ func (u *User) newMFASession() (*session.Session, error) {
 				SecretAccessKey: *getSessionTokenOutput.Credentials.SecretAccessKey,
 				SessionToken:    *getSessionTokenOutput.Credentials.SessionToken,
 			}),
-			Region: aws.String(u.Profile.Region),
+			Region: aws.String(u.BaseProfile.Region),
 		},
 	})
 	if err != nil {
@@ -180,14 +181,15 @@ func (u *User) CreateVirtualMFADevice() error {
 		return fmt.Errorf("unable to create virtual MFA: %w", err)
 	}
 
-	u.Profile.MFASerial = *mfaDeviceOutput.VirtualMFADevice.SerialNumber
+	u.BaseProfile.MFASerial = *mfaDeviceOutput.VirtualMFADevice.SerialNumber
+	u.RoleProfile.MFASerial = *mfaDeviceOutput.VirtualMFADevice.SerialNumber
 
 	// For the QR code, create a string that encodes:
 	// otpauth://totp/$virtualMFADeviceName@$AccountName?secret=$Base32String
 	// https://docs.aws.amazon.com/sdk-for-go/api/service/iam/#VirtualMFADevice
 	content := fmt.Sprintf("otpauth://totp/%s@%s?secret=%s",
 		*mfaDeviceInput.VirtualMFADeviceName,
-		u.Profile.Name,
+		u.BaseProfile.Name,
 		mfaDeviceOutput.VirtualMFADevice.Base32StringSeed,
 	)
 
@@ -245,7 +247,7 @@ func getMFATokenPair() MFATokenPair {
 // EnableVirtualMFADevice enables the user's MFA device
 func (u *User) EnableVirtualMFADevice() error {
 	log.Println("Enabling the virtual MFA device")
-	if u.Profile.MFASerial == "" {
+	if u.BaseProfile.MFASerial == "" {
 		return fmt.Errorf("profile MFA serial must be set")
 	}
 
@@ -260,7 +262,7 @@ func (u *User) EnableVirtualMFADevice() error {
 	enableMFADeviceInput := &iam.EnableMFADeviceInput{
 		AuthenticationCode1: aws.String(mfaTokenPair.Token1),
 		AuthenticationCode2: aws.String(mfaTokenPair.Token2),
-		SerialNumber:        aws.String(u.Profile.MFASerial),
+		SerialNumber:        aws.String(u.BaseProfile.MFASerial),
 		UserName:            aws.String(u.Name),
 	}
 
@@ -327,16 +329,16 @@ func (u *User) RotateAccessKeys() error {
 // profile.
 func (u *User) AddVaultProfile() error {
 	creds := credentials.Value{AccessKeyID: u.AccessKeyID, SecretAccessKey: u.SecretAccessKey}
-	provider := &vault.KeyringProvider{Keyring: *u.Keyring, Profile: u.Profile.Name}
+	provider := &vault.KeyringProvider{Keyring: *u.Keyring, Profile: u.BaseProfile.Name}
 
 	err := provider.Store(creds)
 	if err != nil {
 		return fmt.Errorf("unable to store credentials: %w", err)
 	}
 
-	log.Printf("Added credentials to profile %q in vault", u.Profile.Name)
+	log.Printf("Added credentials to profile %q in vault", u.BaseProfile.Name)
 
-	err = deleteSession(u.Profile.Name, u.Config, u.Keyring)
+	err = deleteSession(u.BaseProfile.Name, u.Config, u.Keyring)
 	if err != nil {
 		return fmt.Errorf("unable to delete session: %w", err)
 	}
@@ -352,19 +354,38 @@ func (u *User) UpdateAWSConfigFile() error {
 	if err != nil {
 		return fmt.Errorf("unable to load aws config file: %w", err)
 	}
-	// add the profile
-	sectionName := fmt.Sprintf("profile %s", u.Profile.Name)
-	section, err := iniFile.NewSection(sectionName)
+	// add the base profile
+	baseSectionName := fmt.Sprintf("profile %s", u.BaseProfile.Name)
+	baseSection, err := iniFile.NewSection(baseSectionName)
 	if err != nil {
-		return fmt.Errorf("error creating section %q: %w", u.Profile.Name, err)
+		return fmt.Errorf("error creating section %q: %w", u.BaseProfile.Name, err)
 	}
-	if err = section.ReflectFrom(&u.Profile); err != nil {
+	if err = baseSection.ReflectFrom(&u.BaseProfile); err != nil {
 		return fmt.Errorf("error mapping profile to ini file: %w", err)
 	}
-	_, err = section.NewKey("output", u.Output)
+	_, err = baseSection.NewKey("output", u.Output)
 	if err != nil {
 		return fmt.Errorf("unable to add output key: %w", err)
 	}
+
+	// add the role profile
+	roleSectionName := fmt.Sprintf("profile %s", u.RoleProfile.Name)
+	roleSection, err := iniFile.NewSection(roleSectionName)
+	if err != nil {
+		return fmt.Errorf("error creating section %q: %w", u.RoleProfile.Name, err)
+	}
+	_, err = roleSection.NewKey("source_profile", u.BaseProfile.Name)
+	if err != nil {
+		return fmt.Errorf("unable to add source profile: %w", err)
+	}
+	if err = roleSection.ReflectFrom(&u.RoleProfile); err != nil {
+		return fmt.Errorf("error mapping profile to ini file: %w", err)
+	}
+	_, err = roleSection.NewKey("output", u.Output)
+	if err != nil {
+		return fmt.Errorf("unable to add output key: %w", err)
+	}
+
 	// save it back to the aws config path
 	return iniFile.SaveTo(u.Config.Path)
 }
@@ -372,7 +393,7 @@ func (u *User) UpdateAWSConfigFile() error {
 // RemoveVaultSession removes the aws-vault session for the profile.
 func (u *User) RemoveVaultSession() error {
 	log.Printf("Removing aws-vault session")
-	err := deleteSession(u.Profile.Name, u.Config, u.Keyring)
+	err := deleteSession(u.BaseProfile.Name, u.Config, u.Keyring)
 	if err != nil {
 		return fmt.Errorf("unable to delete session: %w", err)
 	}
@@ -479,8 +500,16 @@ func main() {
 		log.Fatal(err)
 	}
 
-	profile := vault.Profile{
-		Name: options.AwsProfile,
+	baseProfile := vault.Profile{
+		Name:   options.AwsProfile,
+		Region: options.AwsRegion,
+	}
+
+	roleProfile := vault.Profile{
+		Name: fmt.Sprintf("%s-%s",
+			options.AwsProfile,
+			options.Role,
+		),
 		RoleARN: fmt.Sprintf("arn:%s:iam::%d:role/%s",
 			partition,
 			options.AwsAccountID,
@@ -510,14 +539,19 @@ func main() {
 		log.Fatal(err)
 	}
 	user := User{
-		Name:       options.IAMUser,
-		Profile:    &profile,
-		Output:     options.Output,
-		Config:     config,
-		QrTempFile: tempfile,
-		Keyring:    keyring,
+		Name:        options.IAMUser,
+		BaseProfile: &baseProfile,
+		RoleProfile: &roleProfile,
+		Output:      options.Output,
+		Config:      config,
+		QrTempFile:  tempfile,
+		Keyring:     keyring,
 	}
-	err = checkExistingAWSProfile(profile.Name, config)
+	err = checkExistingAWSProfile(baseProfile.Name, config)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = checkExistingAWSProfile(roleProfile.Name, config)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -501,15 +501,14 @@ func main() {
 	}
 
 	baseProfile := vault.Profile{
-		Name:   options.AwsProfile,
+		Name: fmt.Sprintf("%s-base",
+			options.AwsProfile,
+		),
 		Region: options.AwsRegion,
 	}
 
 	roleProfile := vault.Profile{
-		Name: fmt.Sprintf("%s-%s",
-			options.AwsProfile,
-			options.Role,
-		),
+		Name: options.AwsProfile,
 		RoleARN: fmt.Sprintf("arn:%s:iam::%d:role/%s",
 			partition,
 			options.AwsAccountID,

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/99designs/aws-vault v1.0.1-0.20191030013236-08380e6561cc h1:LvkmVHxD4
 github.com/99designs/aws-vault v1.0.1-0.20191030013236-08380e6561cc/go.mod h1:uMZxYSIbSixdBvLRO46R1OOeUY+J0crm/3mRsO2v+XU=
 github.com/99designs/keyring v1.1.3 h1:mEV3iyZWjkxQ7R8ia8GcG97vCX5zQQ7n4o8R2BylwQY=
 github.com/99designs/keyring v1.1.3/go.mod h1:657DQuMrBZRtuL/voxVyiyb6zpMehlm5vLB9Qwrv904=
-github.com/99designs/keyring v1.1.4 h1:x0g0zQ9bQKgNsLo0XSXAy1H8Q1RG/td+5OXJt+Ci8b8=
-github.com/99designs/keyring v1.1.4/go.mod h1:657DQuMrBZRtuL/voxVyiyb6zpMehlm5vLB9Qwrv904=
 github.com/99designs/keyring v1.1.5 h1:wLv7QyzYpFIyMSwOADq1CLTF9KbjbBfcnfmOGJ64aO4=
 github.com/99designs/keyring v1.1.5/go.mod h1:7hsVvt2qXgtadGevGJ4ujg+u8m6SpJ5TpHqTozIPqf0=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
@@ -11,8 +9,6 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/aws/aws-sdk-go v1.25.17/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
-github.com/aws/aws-sdk-go v1.29.34 h1:yrzwfDaZFe9oT4AmQeNNunSQA7c0m2chz0B43+bJ1ok=
-github.com/aws/aws-sdk-go v1.29.34/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTgahTma5Xg=
 github.com/aws/aws-sdk-go v1.30.27 h1:9gPjZWVDSoQrBO2AvqrWObS6KAZByfEJxQoCYo4ZfK0=
 github.com/aws/aws-sdk-go v1.30.27/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/danieljoos/wincred v1.0.2 h1:zf4bhty2iLuwgjgpraD2E9UbvO+fe54XXGJbOwe23fU=
@@ -122,8 +118,6 @@ gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8
 gopkg.in/go-playground/validator.v9 v9.31.0 h1:bmXmP2RSNtFES+bn4uYuHT7iJFJv7Vj+an+ZQdDaD1M=
 gopkg.in/go-playground/validator.v9 v9.31.0/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=
 gopkg.in/ini.v1 v1.49.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
-gopkg.in/ini.v1 v1.55.0 h1:E8yzL5unfpW3M6fz/eB7Cb5MQAYSZ7GKo4Qth+N2sgQ=
-gopkg.in/ini.v1 v1.55.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/ini.v1 v1.56.0 h1:DPMeDvGTM54DXbPkVIZsp19fp/I2K7zwA/itHYHKo8Y=
 gopkg.in/ini.v1 v1.56.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=


### PR DESCRIPTION
One of the problems with have with generating a single AWS profile in `~/.aws/config` with an IAM role is that it breaks aws-vault's key rotation (e.g., `aws-vault rotate <profile-name>`). This PR splits out the profile definitions. The first is the base profile which contains the long lived AWS Access Keys that can be rotated with `aws-vault rotate`. The second profile is the one tied to the IAM role you wish to assume and only uses temporary credentials.

AWS Profiles will look like the following 
```
[profile corp-id-base]
mfa_serial=arn:aws:iam::123456789012:mfa/alice
region=us-west-2
output=json

[profile corp-id]
source_profile=corp-id-base
mfa_serial=arn:aws:iam::123456789012:mfa/alice
role_arn=arn:aws:iam::123456789012:role/admin
region=us-west-2
output=json
```

**Testing**
* Tested against commercial and govcloud accounts