### PR TITLE
Update repo to latest CLI standards

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,10 @@ jobs:
             - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
             - go-mod-sources-v1-{{ checksum "go.sum" }}
       - run:
-          name: Run pre-commit and Go tests
+          name: Run pre-commit
+          command: pre-commit run -a
+      - run:
+          name: Run Go tests
           command: make test
       - save_cache:
           key: pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-dist
+bin/
+dist/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,35 @@
+linters-settings:
+  govet:
+    check-shadowing: true
+  goimports:
+    # put imports beginning with prefix after 3rd-party packages;
+    # it's a comma-separated list of prefixes
+    local-prefixes: github.com/trussworks/find-guardduty-user
+
+linters:
+  enable:
+    - deadcode
+    - errcheck
+    - gofmt
+    - goimports
+    - golint
+    - gosec
+    - govet
+    - ineffassign
+    - staticcheck
+    - structcheck
+    - typecheck
+    - varcheck
+  disable:
+    - gosimple #deprecated https://github.com/golangci/golangci-lint/issues/357
+    - unused #deprecated https://github.com/dominikh/go-tools/tree/master/cmd/unused
+  fast: false
+
+issues:
+  # golangci-lint excludes by default some checks they consider "annoying"
+  # A better practice is for each repo to choose which ones to disable
+  exclude-use-default: false
+  fix: true
+
+run:
+  modules-download-mode: readonly

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+env:
+  - GO111MODULE=on
 before:
   hooks:
     - go mod download
@@ -18,14 +20,14 @@ brews:
       name: trussworks-infra
       email: infra+github@truss.works
 archives:
-- replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    386: i386
-    amd64: x86_64
+  -
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      amd64: x86_64
 checksum:
   name_template: 'checksums.txt'
+  algorithm: sha256
 snapshot:
   name_template: "{{ .Tag }}-next"
 changelog:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,16 +7,18 @@ repos:
   - repo: git://github.com/pre-commit/pre-commit-hooks
     rev: v3.1.0
     hooks:
-      - id: check-json
       - id: check-merge-conflict
       - id: check-yaml
       - id: detect-private-key
-      - id: pretty-format-json
-        args:
-          - --autofix
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
     rev: v0.23.1
     hooks:
       - id: markdownlint
+
+  - repo: git://github.com/trussworks/pre-commit-hooks
+    rev: v0.0.4
+    hooks:
+      - id: circleci-validate
+      - id: goreleaser-check

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,19 @@
-.PHONY: ensure_pre_commit
-ensure_pre_commit: .git/hooks/pre-commit ## Ensure pre-commit is installed
-.git/hooks/pre-commit: /usr/local/bin/pre-commit
-	pre-commit install
-	pre-commit install-hooks
+# goreleaser removes the `v` prefix when building and this does too
+VERSION = 0.0.1
 
-.PHONY: pre_commit_tests
-pre_commit_tests: ensure_pre_commit ## Run pre-commit tests
-	pre-commit run --all-files --show-diff-on-failure
+ifdef CIRCLECI
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Linux)
+		LDFLAGS=-linkmode external -extldflags -static
+	endif
+endif
+
+.PHONY: help
+help:  ## Print the help documentation
+	@grep -E '^[/a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+bin/setup-new-aws-user: ## Build setup-new-aws-user
+	go build -ldflags "$(LDFLAGS) -X main.version=${VERSION}" -o bin/setup-new-aws-user ./cmd/
 
 .PHONY: test
 test: pre_commit_tests
@@ -15,3 +22,19 @@ test: pre_commit_tests
 .PHONY: clean
 clean:
 	rm -f .*.stamp
+	rm -rf ./bin
+	rm -rf ./dist
+
+.PHONY: goreleaser_check
+goreleaser_check: ## Goreleaser check configuration
+	goreleaser check
+
+.PHONY: goreleaser_build
+goreleaser_build: ## Goreleaser build configuration
+	goreleaser build --snapshot --rm-dist
+
+.PHONY: goreleaser_test
+goreleaser_test: ## Goreleaser test configuration
+	goreleaser --snapshot --skip-publish --rm-dist
+
+default: help

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ bin/setup-new-aws-user: ## Build setup-new-aws-user
 	go build -ldflags "$(LDFLAGS) -X main.version=${VERSION}" -o bin/setup-new-aws-user ./cmd/
 
 .PHONY: test
-test: pre_commit_tests
+test:
 	go test ./cmd/...
 
 .PHONY: clean

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,6 +25,9 @@ import (
 const maxNumAccessKeys = 2
 const maxMFATokenPromptAttempts = 5
 
+// version is the published version of the utility
+var version string
+
 var validate *validator.Validate
 
 // MFATokenPair holds two MFA tokens for enabling virtual
@@ -41,6 +44,7 @@ type cliOptions struct {
 	IAMUser      string `required:"true" long:"iam-user" description:"The IAM user name"`
 	Role         string `required:"true" long:"role" description:"The user role type"`
 	Output       string `long:"output" default:"json" description:"The AWS CLI output format"`
+	Version      bool   `long:"version" description:"Print the version and exit"`
 }
 
 // User holds information for the AWS user being configured by this script
@@ -485,13 +489,29 @@ func getPartition(region string) (string, error) {
 func main() {
 	// parse command line flags
 	var options cliOptions
-	parser := flags.NewParser(&options, flags.Default)
+	parser := flags.NewParser(&options, flags.HelpFlag|flags.PassDoubleDash)
 
-	_, err := parser.Parse()
-	if err != nil {
-		log.Fatal(err)
+	// Parse the command line flags
+	_, errParse := parser.Parse()
+
+	// Print the version and exit
+	if options.Version {
+		// Disable output not related to version before printing
+		log.SetFlags(0)
+		if len(version) == 0 {
+			log.Println("development")
+		} else {
+			log.Println(version)
+		}
+		os.Exit(0)
 	}
 
+	// Manage parse errors after checking for version
+	if errParse != nil {
+		log.Fatal(errParse)
+	}
+
+	// Validator used to validate input options for MFA
 	validate = validator.New()
 
 	// initialize things

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -450,7 +450,7 @@ func generateQrCode(payload string, tempFile *os.File) error {
 
 	// Write the QR PNG to the Temp File
 	if _, err := tempFile.Write(qr); err != nil {
-		tempFile.Close()
+		_ = tempFile.Close()
 		return err
 	}
 	return nil
@@ -542,7 +542,12 @@ func main() {
 		log.Fatal(err)
 	}
 	// Cleanup after ourselves
-	defer os.Remove(tempfile.Name())
+	defer func() {
+		errRemove := os.Remove(tempfile.Name())
+		if errRemove != nil {
+			log.Fatal(errRemove)
+		}
+	}()
 
 	config, err := vault.LoadConfigFromEnv()
 	if err != nil {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -27,7 +27,10 @@ func newConfigFile(t *testing.T, b []byte) string {
 
 func TestExistingAWSProfile(t *testing.T) {
 	f := newConfigFile(t, defaultConfig)
-	defer os.Remove(f)
+	defer func() {
+		errRemove := os.Remove(f)
+		assert.NoError(t, errRemove)
+	}()
 	config, _ := vault.LoadConfig(f)
 	baseProfile := vault.Profile{
 		Name:   "test",
@@ -52,7 +55,10 @@ func TestExistingAWSProfile(t *testing.T) {
 
 func TestUpdateAWSConfigFile(t *testing.T) {
 	f := newConfigFile(t, defaultConfig)
-	defer os.Remove(f)
+	defer func() {
+		errRemove := os.Remove(f)
+		assert.NoError(t, errRemove)
+	}()
 	baseProfile := vault.Profile{
 		Name:   "test-base",
 		Region: "us-west-2",
@@ -81,7 +87,10 @@ func TestUpdateAWSConfigFile(t *testing.T) {
 func TestGenerateQrCode(t *testing.T) {
 	tempFile, err := ioutil.TempFile("", "temp-qr.*.png")
 	assert.NoError(t, err)
-	defer os.Remove(tempFile.Name())
+	defer func() {
+		errRemove := os.Remove(tempFile.Name())
+		assert.NoError(t, errRemove)
+	}()
 
 	err = generateQrCode("otpauth://totp/super@top?secret=secret", tempFile)
 	assert.NoError(t, err)

--- a/go.mod
+++ b/go.mod
@@ -20,3 +20,8 @@ require (
 	gopkg.in/go-playground/validator.v9 v9.31.0
 	gopkg.in/ini.v1 v1.57.0
 )
+
+// Update to ignore compiler warnings on macOS catalina
+// https://github.com/keybase/go-keychain/pull/55
+// https://github.com/99designs/aws-vault/pull/427
+replace github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/99designs/aws-vault v1.0.1-0.20191030013236-08380e6561cc h1:LvkmVHxD4e0kBiGmyMIu+IsK9ZIa1Ky9ESI2xmM9IcQ=
 github.com/99designs/aws-vault v1.0.1-0.20191030013236-08380e6561cc/go.mod h1:uMZxYSIbSixdBvLRO46R1OOeUY+J0crm/3mRsO2v+XU=
+github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 h1:/vQbFIOMbk2FiG/kXiLl8BRyzTWDw7gX/Hz7Dd5eDMs=
+github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4/go.mod h1:hN7oaIRCjzsZ2dE+yG5k+rsdt3qcwykqK6HVGcKwsw4=
 github.com/99designs/keyring v1.1.3 h1:mEV3iyZWjkxQ7R8ia8GcG97vCX5zQQ7n4o8R2BylwQY=
 github.com/99designs/keyring v1.1.3/go.mod h1:657DQuMrBZRtuL/voxVyiyb6zpMehlm5vLB9Qwrv904=
 github.com/99designs/keyring v1.1.5 h1:wLv7QyzYpFIyMSwOADq1CLTF9KbjbBfcnfmOGJ64aO4=


### PR DESCRIPTION
There are a lot of changes here so I'll list them out:

- Update goreleaser config
- Run pre-commit with goreleaser and circleci config checks
- Remove warning when binary compiled for macOS with aws-vault keychain
- Add a golangci-lint config file
- Update `Makefile` to include goreleaser commands, help as default, and building in bin directory
- Add a `--version` flag to print the version and exit
- Fix up golangci-lint errors for `errcheck` linter
- Run pre-commit and go tests separately in circleci

I won't be cutting a new release of this tool after this change. I have other updates that I want to incorporate into this tool before a release is made.