### PR TITLE
Add auto-approve step for go code by dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,9 +1,13 @@
+# Settings found in https://dependabot.com/docs/config-file/
 version: 1
 update_configs:
-  # Keep go modules up to date, batching pull requests weekly
   - package_manager: "go:modules"
     directory: "/"
     update_schedule: "weekly"
-    # Apply dependencies label to PRs
+    automerged_updates:
+      - match:
+          dependency_type: "all"
+          update_type: "semver:minor"
     default_labels:
-      - "dependencies"
+      - dependencies
+      - automerge

--- a/.github/workflows/go-auto-approve.yml
+++ b/.github/workflows/go-auto-approve.yml
@@ -1,0 +1,59 @@
+name: auto approve and tidy
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/gosum.yml'
+      - 'go.mod'
+      - 'go.sum'
+
+# job level conditions don't seem to work at the moment
+# https://github.community/t5/GitHub-Actions/Status-of-workflows-with-no-running-jobs/td-p/37160
+# which is why github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]' is
+# repeated over and over
+jobs:
+  tidy:
+    name: run go mod tidy and updated
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v1
+        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+      - name: reattach HEAD to Head Ref
+        # b/c checkout action leaves in detached head state https://github.com/actions/checkout/issues/6
+        run: git checkout "$(echo ${{ github.head_ref }})"
+        if: github.head_ref != '' && (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
+      - name: setup go
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.14'
+      - name: Tidy
+        run: |
+          go version
+          go mod tidy
+        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+      - name: set up Git
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+      - name: commit and push changes
+        run: |
+          git add .
+          if output=$(git status --porcelain) && [ ! -z "$output" ]; then
+            git commit -m 'Fix go modules'
+            git push
+          fi
+        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+  approve:
+    name: auto-approve dependabot PRs
+    runs-on: ubuntu-latest
+    needs: [tidy]
+    steps:
+      - name: approve
+        uses: hmarr/auto-approve-action@v2.0.0
+        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This is copied from milmove. You can see the original code here: https://github.com/transcom/mymove/blob/master/.github/workflows/go-auto-approve.yml

The point is to allow dependabot to suggest and auto-merge changes.