### PR TITLE
Allow users to assume MFA device is already configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ region=us-west-2
 output=json
 ```
 
+### MFA Management
+
+This tool will help create and enable a virtual MFA device. The interface for the MFA device is a QR code
+which will be shown to the user during setup. This QR code can be used with a password manager to provide the
+One Time Passwords (OTP) values asked for in the script.
+
+In the case where the user has a virtual MFA device already set up they can choose not to provision a new one.
+This is done by issuing the `--no-mfa` flag on the command line in conjunction with the regular command from
+above.
+
 ## Development setup
 
 1. First, install these packages: `brew install pre-commit direnv go`

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -27,7 +27,10 @@ const (
 	IAMRoleFlag string = "iam-role"
 
 	// OutputFlag is the Output Flag
-	OutputFlag = "output"
+	OutputFlag string = "output"
+
+	// NoMFAFlag indicates that no MFA device should be configured as one exists
+	NoMFAFlag string = "no-mfa"
 
 	// VerboseFlag is the Verbose Flag
 	VerboseFlag string = "verbose"

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -235,6 +235,9 @@ func (u *User) GetMFADevice(logger *log.Logger) error {
 	if len(mfaDeviceOutput.MFADevices) == 0 {
 		return errors.New("no MFA devices registered")
 	}
+	if len(mfaDeviceOutput.MFADevices) > 1 {
+		return errors.New("more than one MFA device registered, no way to choose")
+	}
 	mfaDevice := mfaDeviceOutput.MFADevices[0]
 
 	u.BaseProfile.MFASerial = *mfaDevice.SerialNumber


### PR DESCRIPTION
This was a useful modification for MilMove where new credentials were provided after the MFA was already set up. Passing the flag `--no-mfa` will retrieve the existing MFA serial number instead of creating and enabling a new device.

Pivotal Story:
- [Allow no MFA](https://www.pivotaltracker.com/story/show/173317533)

Notes: This could possibly be a separate subcommand like `setup-new-aws-user update-creds` but for now it feels better to keep things simplified until we know more about the workflow around setting up accounts.