### PR TITLE
Fix goreleaser build to work with building multiple go files

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,7 @@ builds:
     - linux
   goarch:
     - amd64
-  main: ./cmd/main.go
+  main: ./cmd/
 brews:
   - description: "A tool that creates a virtual MFA device and rotates access keys for a new AWS user."
     github:


### PR DESCRIPTION
Goreleaser needs to build the entire directory `./cmd` instead of just `./cmd/main.go` now that we have multiple go files.