### PR TITLE
Add the logger to the user struct to pass around

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -43,6 +43,7 @@ func TestExistingAWSProfile(t *testing.T) {
 	keyring, err := getKeyring("test")
 	assert.NoError(t, err)
 	user := User{
+		Logger:      logger,
 		Name:        "test",
 		BaseProfile: &baseProfile,
 		Output:      "json",
@@ -76,6 +77,7 @@ func TestUpdateAWSConfigFile(t *testing.T) {
 	keyring, err := getKeyring("test")
 	assert.NoError(t, err)
 	user := User{
+		Logger:      logger,
 		Name:        "test-user",
 		BaseProfile: &baseProfile,
 		RoleProfile: &roleProfile,
@@ -84,7 +86,7 @@ func TestUpdateAWSConfigFile(t *testing.T) {
 		QrTempFile:  nil,
 		Keyring:     keyring,
 	}
-	err = user.UpdateAWSConfigFile(logger)
+	err = user.UpdateAWSConfigFile()
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
I'm not sure why I didn't think of this in my [logging PR](https://github.com/trussworks/setup-new-aws-user/pull/66). By passing logger as part of the `User` struct we eliminate the need to pass a logger around via functions calls. This really simplifies the code and makes it easier to read. 

Also, the more I consider it the `User` struct is really just the configuration for the `setup` function. When I think of it in that context then the `Logger` doesn't feel out of place in the struct. So in a future PR we might want to rename `User` to `SetupConfig`.