### PR TITLE
Don't fault if aws-profile already exists

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -13,11 +13,6 @@ import (
 // Test logger
 var logger = log.New(os.Stdout, "", log.LstdFlags)
 
-var defaultConfig = []byte(`[profile test]
-region=us-west-2
-output=json
-`)
-
 func newConfigFile(t *testing.T, b []byte) string {
 	f, err := ioutil.TempFile("", "aws-config")
 	if err != nil {
@@ -29,36 +24,12 @@ func newConfigFile(t *testing.T, b []byte) string {
 	return f.Name()
 }
 
-func TestExistingAWSProfile(t *testing.T) {
-	f := newConfigFile(t, defaultConfig)
-	defer func() {
-		errRemove := os.Remove(f)
-		assert.NoError(t, errRemove)
-	}()
-	config, _ := vault.LoadConfig(f)
-	baseProfile := vault.Profile{
-		Name:   "test",
-		Region: "us-west-2",
-	}
-	keyring, err := getKeyring("test")
-	assert.NoError(t, err)
-	user := User{
-		Logger:      logger,
-		Name:        "test",
-		BaseProfile: &baseProfile,
-		Output:      "json",
-		Config:      config,
-		QrTempFile:  nil,
-		Keyring:     keyring,
-	}
-
-	err = checkExistingAWSProfile(baseProfile.Name, user.Config, logger)
-	assert.Error(t, err)
-	err = checkExistingAWSProfile("missing", user.Config, logger)
-	assert.NoError(t, err)
-}
-
 func TestUpdateAWSConfigFile(t *testing.T) {
+
+	var defaultConfig = []byte(`[profile test]
+region=us-west-2
+output=json
+`)
 	f := newConfigFile(t, defaultConfig)
 	defer func() {
 		errRemove := os.Remove(f)

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -551,16 +551,6 @@ func openQrCode(tempFile *os.File) error {
 	return nil
 }
 
-func checkExistingAWSProfile(profileName string, config *vault.Config, logger *log.Logger) error {
-	logger.Printf("Checking whether profile %q exists in AWS config file\n", profileName)
-	_, exists := config.Profile(profileName)
-	if exists {
-		return fmt.Errorf("Profile already exists in AWS config file: %s", profileName)
-	}
-
-	return nil
-}
-
 func getPartition(region string) (string, error) {
 	partition, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), region)
 	if !ok {
@@ -678,14 +668,6 @@ func setupUserFunction(cmd *cobra.Command, args []string) error {
 		QrTempFile:  tempfile,
 		Keyring:     keyring,
 		NoMFA:       noMFA,
-	}
-	err = checkExistingAWSProfile(baseProfile.Name, config, logger)
-	if err != nil {
-		logger.Fatal(err)
-	}
-	err = checkExistingAWSProfile(roleProfile.Name, config, logger)
-	if err != nil {
-		logger.Fatal(err)
 	}
 	user.Setup()
 


### PR DESCRIPTION
It's a hinderance that this code checks for the aws-vault profile and then fails if it exists. There are user experience cases where the aws credentials that aws-vault put in the OSX keychain are deleted and need to be re-added. Unfortunately this check then forces a user to modify their working `~/.aws/config` and to delete existing profiles. But the aws-vault golang code doesn't care and neither does ours. So its no harm for it to run again as it doesn't make any changes. This improves the tools user experience.