### PR TITLE
Re-add the mfa device to the base profile. 

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -415,8 +415,9 @@ func (sc *SetupConfig) UpdateAWSConfigFile() error {
 	}
 
 	sc.BaseProfile = &vault.ProfileSection{
-		Name:   sc.BaseProfileName,
-		Region: sc.Region,
+		Name:      sc.BaseProfileName,
+		Region:    sc.Region,
+		MfaSerial: sc.MFASerial,
 	}
 
 	// Add the base profile

--- a/cmd/setup_test.go
+++ b/cmd/setup_test.go
@@ -91,7 +91,7 @@ output=json
 
 	testBaseSection, ok := config.ProfileSection("test-id-base")
 	suite.True(ok)
-	suite.Equal(len(testBaseSection.MfaSerial), 0)
+	suite.Equal(testBaseSection.MfaSerial, mfaSerial)
 	suite.Equal(testBaseSection.Region, "us-west-2")
 	// suite.Equal(testBaseSection.Output, "json")
 


### PR DESCRIPTION
This is needed for several actions that use the base credentials for provisioning AWS. In previous work I had removed it because I didn't have any test cases to use that needed the MFA device. I tested this locally and was able to get the desired config file. I also updated the associated test.

I'll release this as a minor update, v0.5.1.