### PR TITLE
Replace circleci-docker-primary with circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
 version: 2.1
 
 references:
-  circleci-docker-primary: &circleci-docker-primary trussworks/circleci-docker-primary:27ce46fbf2088bd960cf75610908a7990514f84b
+  circleci: &circleci trussworks/circleci:56e6e6ef96436eff868243a7a0e42322c4df43c5
 
 jobs:
   test:
     docker:
-      - image: *circleci-docker-primary
+      - image: *circleci
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
[create a docker image to replace circleci-docker-primary](https://www.pivotaltracker.com/story/show/174387422)

- Replace `circleci-docker-primary` with new image `circleci`