### PR TITLE
bump go to 1.16

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -19,7 +19,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14.x
+          go-version: 1.16.x
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -21,7 +21,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v1
         with:
-          go-version: "1.14"
+          go-version: "1.16"
       - name: Tidy
         run: |
           go version

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/trussworks/setup-new-aws-user
 
-go 1.14
+go 1.16
 
 require (
 	github.com/99designs/aws-vault v1.0.1-0.20200507051055-ae369037cc75

--- a/go.sum
+++ b/go.sum
@@ -448,7 +448,6 @@ golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
-golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 h1:4nGaVu0QrbjT/AK2PRLuQfQuh6DJve+pELhqTdAj3x0=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -586,7 +585,6 @@ golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=


### PR DESCRIPTION
https://github.com/trussworks/setup-new-aws-user/pull/151 failed with the following error during `go mod tidy`:

```
github.com/trussworks/setup-new-aws-user/cmd imports
	github.com/spf13/viper imports
	github.com/spf13/afero imports
	io/fs: package io/fs is not in GOROOT (/opt/hostedtoolcache/go/1.14.15/x64/src/io/fs)
github.com/trussworks/setup-new-aws-user/cmd imports
	github.com/spf13/viper imports
	github.com/spf13/afero tested by
	github.com/spf13/afero.test imports
	testing/fstest: package testing/fstest is not in GOROOT (/opt/hostedtoolcache/go/1.14.15/x64/src/testing/fstest)
Error: Process completed with exit code 1.
```

`io/fs` and `testing/fstest` are new packages in Go 1.16 (https://golang.org/doc/go1.16#fs). In order to keep dependencies up to date that have migrated to Go 1.16, we need to upgrade to 1.16 as well.