### PR TITLE
ML - Prevent AWS MFA code reuse

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -16,6 +16,8 @@ import (
 
 const maxMFATokenPromptAttempts = 5
 
+var globalMFACodeMap = make(map[string]string)
+
 func promptMFAtoken(messagePrefix string, logger *log.Logger) string {
 	var token string
 	for attempts := maxMFATokenPromptAttempts; token == "" && attempts > 0; attempts-- {
@@ -29,6 +31,12 @@ func promptMFAtoken(messagePrefix string, logger *log.Logger) string {
 			logger.Println("MFA token must be 6 digits. Please try again.")
 			continue
 		}
+
+		if _, found := globalMFACodeMap[t]; found {
+			logger.Println("MFA token has already been used. Please try again.")
+			continue
+		}
+		globalMFACodeMap[t] = t
 		token = t
 	}
 	return token


### PR DESCRIPTION
# Can setup-new-aws-user catch when you use the same MFA code? [#180592054](https://www.pivotaltracker.com/story/show/180592054)

<!--
    Insert the tracker story URL in the markdown link above
    e.g., Fixes [#1324235](http://path/to/storyid/1324235)
--->

Changes proposed in this pull request:

- Add a map to store used AWS MFA codes in memory

## Checklist for Testing changes

<!--
    - [x] a checked item
    - [ ] an unchecked item
-->

- [ ] Review [Integration / End 2 End Testing](https://github.com/trussworks/setup-new-aws-user#integration--end-2-end-testing) instructions
- [ ] Create a temporary IAM test user in an AWS account that you are able to admin. "Engineer" role should be enough for testing.
- [ ] Generate an Access Key for the user.
- [ ] Run the `setup` command with the IAM test user. DO NOT use an existing aws-profile-name! This will overwrite your existing AWS vault profile. DO use the real AWS Account ID. You can find the Account ID mappings for Truss accounts [here](https://github.com/trussworks/legendary-waddle/blob/main/docs/how-to/setup-new-user.md#provision-temporary-aws-access-keys-for-new-user).
```
go run ./cmd setup --iam-role engineer --iam-user <new_user> --iam-role <ROLE-NAME> --aws-profile-account <account profile>:<account id>
```
- [ ] Follow [steps 3-5 ](https://github.com/trussworks/legendary-waddle/blob/main/docs/how-to/setup-new-user.md#provision-temporary-aws-access-keys-for-new-user) to setup the MFA device using the Access Keys you generated. Please attempt to break the workflow by reusing MFA codes. You should get this response `MFA token has already been used. Please try again.` instead of the script erroring out.
- [ ] Run a command to confirm that the test profile works as intended:
`AWS_VAULT_KEYCHAIN_NAME=login aws-vault exec test-profile-name -- aws sts get-caller-identity`


______________________________________________________________________