### PR TITLE
Update precommit Git URLs to use HTTPS instead of Git protocol

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
-  - repo: git://github.com/golangci/golangci-lint
+  - repo: https://github.com/golangci/golangci-lint
     rev: v1.27.0
     hooks:
       - id: golangci-lint
 
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.1.0
     hooks:
       - id: check-merge-conflict
@@ -12,12 +12,12 @@ repos:
       - id: detect-private-key
       - id: trailing-whitespace
 
-  - repo: git://github.com/igorshubovych/markdownlint-cli
+  - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.23.1
     hooks:
       - id: markdownlint
 
-  - repo: git://github.com/trussworks/pre-commit-hooks
+  - repo: https://github.com/trussworks/pre-commit-hooks
     rev: v1.0.1
     hooks:
       - id: circleci-validate


### PR DESCRIPTION
GitHub recently [introduced breaking changes](https://github.blog/2021-09-01-improving-git-protocol-security-github/) to remove support for the `git://` protocol and other unencrypted protocols. This breaks our precommit hooks since they use the `git://` protocol. Using `https://` resolves the issue in CI and locally.

Related updates for all repos tracked in [#181773698](https://www.pivotaltracker.com/story/show/181773698).

## Testing Instructions
- Run `pre-commit run -a` locally and confirm that all precommit tests pass.
- Confirm that all CI workflows pass successfully.