### PR TITLE
ci: new token rather than built-in token

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -24,4 +24,4 @@ jobs:
           version: latest
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   goreleaser:
-    runs-on: macos-10.15
+    runs-on: macos-12
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v1.51.2
     hooks:
       - id: golangci-lint
-
+        entry: golangci-lint run --fix --timeout 300s
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:


### PR DESCRIPTION
Changes proposed in this pull request:

- switches back to `GH_TOKEN` rather than `GITHUB_TOKEN` because it didn't work. `GH_TOKEN` is also new
