### PR TITLE
fix: don't panic on invalid flag, bump version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # goreleaser removes the `v` prefix when building and this does too
-VERSION = 0.5.0
+VERSION = 0.6.1
 
 ifdef CIRCLECI
 	UNAME_S := $(shell uname -s)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -53,6 +53,6 @@ func main() {
 	root.AddCommand(versionCommand)
 
 	if err := root.Execute(); err != nil {
-		panic(err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## [setup-new-aws-user should not panic if passed an invalid parameter](https://trello.com/c/BI3Q5kTE/246-setup-new-aws-user-should-not-panic-if-passed-an-invalid-parameter)

Changes proposed in this pull request:

- Exit with graceful exit code `1` instead of `panic` on error.
- Bump Makefile version so `version` command will return correct value.

The linked ticket asks for support for a `--version` flag, but there's already a `version` command documented in CLI output and the `--help` output which should be sufficient.

(Credit to @eeeady, @marycrawford, and @ildeleaf for pairing 💖)